### PR TITLE
Update valut and consul images.

### DIFF
--- a/compose/infrastructure.yml
+++ b/compose/infrastructure.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   consul:
-    image: consul
+    image: hashicorp/consul
     container_name: consul
     restart: unless-stopped
     networks:
@@ -113,7 +113,7 @@ services:
     #   - seq:/data
 
   vault:
-    image: vault
+    image: hashicorp/vault
     container_name: vault
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Updated **Vault** and **Consul** image definitions to align with the latest recommendations.

<a href="https://hub.docker.com/_/vault">Vault deprication notice:</a>
> ...Users of Docker images should pull from [hashicorp/vault](https://hub.docker.com/r/hashicorp/vault) instead of [vault](https://hub.docker.com/_/vault). Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/vault.
<br>

<a href="https://hub.docker.com/_/consul" >Consul deprication notice:</a>
> ...Users of Docker images should pull from [hashicorp/consul](https://hub.docker.com/r/hashicorp/consul) instead of [consul](https://hub.docker.com/_/consul). Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/consul.